### PR TITLE
Add implicit dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.2.8",
+    "@protobuf-ts/runtime": "^2.1.0",
+    "@protobuf-ts/runtime-rpc": "^2.1.0",
     "@types/jasmine": "^3.10.0",
     "google-protobuf": "^3.15.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,10 +136,22 @@
   dependencies:
     "@protobuf-ts/runtime" "^2.0.7"
 
+"@protobuf-ts/runtime-rpc@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.1.0.tgz#928b1438e1ece017b9d6a5166d96ffebb7588760"
+  integrity sha512-i/q2sV2s3quJ0I+WY5mXKHiiabvkggOuyb+m0sDqN1MQXcJ/S9mZo/KZ0Dc5RcH4SFhg7NiFzsw6O1xOvG7GrQ==
+  dependencies:
+    "@protobuf-ts/runtime" "^2.1.0"
+
 "@protobuf-ts/runtime@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.0.7.tgz#a1f43407df4ad32b0b35838c19efae4253eb6f3f"
   integrity sha512-jT8FYEX7NkAzxZXVjshIhtCV/ReuZm/3sCH0GWnaa8woy9VG+He0N+dpj2svaJbkdUThSxJE3zwmJcH0/3vEsw==
+
+"@protobuf-ts/runtime@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.1.0.tgz#3b75084ccffbb02661ab1e6752ec79ec4be85822"
+  integrity sha512-HZwkgJW9SGiE9+0lWKr1X997tmG01/40j+hr9yBVk+hTQcm7Hsf77XhMNtsDjWUOcspG6GBXu8o3g4i3kD5/zQ==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"


### PR DESCRIPTION
Hi! I tried to use this in a project that uses yarn PnP, and it threw this error:

https://classic.yarnpkg.com/lang/en/docs/pnp/troubleshooting/#toc-is-trying-to-require-without-it-being-listed-in-its-dependencies

> This error simply means that the specified package is requiring something without explicitly declaring it in its dependencies. Since this behavior is unsafe and relies on the hoisting being done a certain way, Plug’n’Play doesn’t allow it.

This PR simply adds those implicit dependencies to the top level package.json. Seems like a harmless change, but happy to iterate if you have any concerns.