### PR TITLE
Move @types/jasmine into devDependencies

### DIFF
--- a/.github/workflows/authzed-node.yaml
+++ b/.github/workflows/authzed-node.yaml
@@ -5,6 +5,7 @@ on:
     - '*'
     paths:
     - src/**
+    - package.json
     - .github/workflows/authzed-node.yaml
   push:
     branches:

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "@grpc/grpc-js": "^1.2.8",
     "@protobuf-ts/runtime": "^2.1.0",
     "@protobuf-ts/runtime-rpc": "^2.1.0",
-    "@types/jasmine": "^3.10.0",
     "google-protobuf": "^3.15.3"
   },
   "devDependencies": {
+    "@types/jasmine": "^3.10.0",
     "@protobuf-ts/plugin": "^2.0.7",
     "@types/jest": "^27.0.2",
     "@typescript-eslint/eslint-plugin": "^5.1.0",


### PR DESCRIPTION
Types should always be specified as devDependencies. In this particular case, the inclusion of @types/jasmine in the compiled package leads to conflicts in systems that make use of Jest