### PR TITLE
Add support for custom certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,17 @@ You will have to provide a your own API Token from the [Authzed dashboard] in pl
 ```js
 import { v1 } from '@authzed/authzed-node';
 
-const client = v1.NewClient('t_your_token_here_1234567deadbeef')
+const client = v1.NewClient('t_your_token_here_1234567deadbeef');
+```
+
+Or to use a custom certificate authority, load the CA certificate.
+```js
+import { v1 } from '@authzed/authzed-node';
+import fs from 'fs';
+
+const endpoint = 'localhost:50051';
+const cert = fs.readFileSync('path/to/cert.pem');
+const client = v1.NewClient('t_your_token_here_1234567deadbeef', endpoint, cert);
 ```
 
 ### Performing an API call

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ import { v1 } from '@authzed/authzed-node';
 const client = v1.NewClient('t_your_token_here_1234567deadbeef');
 ```
 
-Or to use a custom certificate authority, load the CA certificate and pass the file reference to `NewClient`.
+Or to use a custom certificate authority, load the CA certificate and pass the file reference to `NewClientWithCustomCert`.
 ```js
 import { v1 } from '@authzed/authzed-node';
 import fs from 'fs';
 
 const endpoint = 'localhost:50051';
 const cert = fs.readFileSync('path/to/cert.pem');
-const client = v1.NewClient('t_your_token_here_1234567deadbeef', endpoint, cert);
+const client = v1.NewClientWithCustomCert('t_your_token_here_1234567deadbeef', endpoint, cert);
 ```
 
 ### Performing an API call

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ import { v1 } from '@authzed/authzed-node';
 const client = v1.NewClient('t_your_token_here_1234567deadbeef');
 ```
 
-Or to use a custom certificate authority, load the CA certificate.
+Or to use a custom certificate authority, load the CA certificate and pass the file reference to `NewClient`.
 ```js
 import { v1 } from '@authzed/authzed-node';
 import fs from 'fs';

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -9,6 +9,13 @@ import { WatchServiceClient } from "./authzedapi/authzed/api/v1/watch_service.gr
 import * as util from "./util";
 import { ClientSecurity } from "./util";
 
+/**
+ * NewClient creates a new client for calling Authzed APIs.
+ * @param token Secret token for authentication.
+ * @param endpoint Uri for communicating with Authzed.
+ * @param security Security level for the connection.
+ * @returns Client for calling Authzed APIs.
+ */
 export function NewClient(
   token: string,
   endpoint = util.authzedEndpoint,
@@ -18,6 +25,13 @@ export function NewClient(
   return NewClientWithChannelCredentials(endpoint, creds);
 }
 
+/**
+ * NewClientWithCustomCert creates a new client for calling Authzed APIs using a custom TLS certificate.
+ * @param token Secret token for authentication.
+ * @param endpoint Uri for communicating with Authzed.
+ * @param certificate Buffer read from certificate file.
+ * @returns Client for calling Authzed APIs.
+ */
 export function NewClientWithCustomCert(
   token: string,
   endpoint = util.authzedEndpoint,
@@ -27,6 +41,12 @@ export function NewClientWithCustomCert(
   return NewClientWithChannelCredentials(endpoint, creds);
 }
 
+/**
+ * NewClientWithChannelCredentials creates a new client for calling Authzed APIs using custom grpc ChannelCredentials.
+ * @param endpoint Uri for communicating with Authzed.
+ * @param creds ChannelCredentials used for grpc.
+ * @returns Client for calling Authzed APIs.
+ */
 export function NewClientWithChannelCredentials(
   endpoint = util.authzedEndpoint,
   creds: ChannelCredentials

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -1,6 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 "use strict";
 
+import { ChannelCredentials } from "@grpc/grpc-js";
 import { PermissionsServiceClient } from "./authzedapi/authzed/api/v1/permission_service.grpc-client";
 import { SchemaServiceClient } from "./authzedapi/authzed/api/v1/schema.grpc-client";
 import { WatchServiceClient } from "./authzedapi/authzed/api/v1/watch_service.grpc-client";
@@ -11,10 +12,25 @@ import { ClientSecurity } from "./util";
 export function NewClient(
   token: string,
   endpoint = util.authzedEndpoint,
-  security: ClientSecurity | Buffer = ClientSecurity.SECURE
+  security: ClientSecurity = ClientSecurity.SECURE
 ) {
   const creds = util.createClientCreds(endpoint, token, security);
+  return NewClientWithChannelCredentials(endpoint, creds);
+}
 
+export function NewClientWithCustomCert(
+  token: string,
+  endpoint = util.authzedEndpoint,
+  certificate: Buffer
+) {
+  const creds = util.createClientCredsWithCustomCert(token, certificate);
+  return NewClientWithChannelCredentials(endpoint, creds);
+}
+
+export function NewClientWithChannelCredentials(
+  endpoint = util.authzedEndpoint,
+  creds: ChannelCredentials
+) {
   const acl = new PermissionsServiceClient(endpoint, creds);
   const ns = new SchemaServiceClient(endpoint, creds);
   const watch = new WatchServiceClient(endpoint, creds);

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -11,7 +11,7 @@ import { ClientSecurity } from "./util";
 export function NewClient(
   token: string,
   endpoint = util.authzedEndpoint,
-  security: ClientSecurity = ClientSecurity.SECURE
+  security: ClientSecurity | Buffer = ClientSecurity.SECURE
 ) {
   const creds = util.createClientCreds(endpoint, token, security);
 


### PR DESCRIPTION
You can now pass in a CA certificate to v1.NewClient constructor if you don't have a certificate installed on your system. For example one for localhost.