### PR TITLE
Export ClientSecurity from v1.ts and v1alpha1.ts

### DIFF
--- a/src/v1.test.ts
+++ b/src/v1.test.ts
@@ -1,5 +1,6 @@
 import {
   CheckPermissionRequest,
+  ClientSecurity,
   NewClient,
   ObjectReference,
   SubjectReference,
@@ -14,7 +15,6 @@ import {
   WriteRelationshipsResponse,
 } from "./v1";
 import * as grpc from "@grpc/grpc-js";
-import { ClientSecurity } from "./util";
 
 describe("a check with an unknown namespace", () => {
   it("should raise a failed precondition", (done) => {

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -87,6 +87,7 @@ export * from "./authzedapi/authzed/api/v1/watch_service";
 export * from "./authzedapi/authzed/api/v1/watch_service.grpc-client";
 export * from "./authzedapi/authzed/api/v1/permission_service.grpc-client";
 export * from "./authzedapi/authzed/api/v1/schema.grpc-client";
+export { ClientSecurity } from './util';
 
 export default {
   NewClient: NewClient,

--- a/src/v1alpha1.test.ts
+++ b/src/v1alpha1.test.ts
@@ -1,5 +1,4 @@
-import { ClientSecurity } from "./util";
-import authzed, { WriteSchemaRequest } from "./v1alpha1";
+import authzed, { ClientSecurity, WriteSchemaRequest } from "./v1alpha1";
 
 describe("a write", () => {
   it("should succeed", (done) => {

--- a/src/v1alpha1.ts
+++ b/src/v1alpha1.ts
@@ -14,6 +14,7 @@ function NewClient(
 }
 
 export * from "./authzedapi/authzed/api/v1alpha1/schema";
+export { ClientSecurity } from './util';
 
 export { NewClient };
 export default {


### PR DESCRIPTION
The ClientSecurity enum is exported from v1.ts and v1alpha1.ts to make it publicly available at the top level.