### PR TITLE
feat: support proxying close method to all clients

### DIFF
--- a/src/v1-promise.test.ts
+++ b/src/v1-promise.test.ts
@@ -47,6 +47,7 @@ describe('a check with an unknown namespace', () => {
       throw new Error('Error should be thrown')
     } catch (err) {
       expect((err as grpc.ServiceError)?.code).toBe(grpc.status.FAILED_PRECONDITION);
+      client.close()
     }
   });
 });
@@ -118,6 +119,8 @@ describe('a check with an known namespace', () => {
     expect(checkResponse?.permissionship).toBe(
       CheckPermissionResponse_Permissionship.HAS_PERMISSION
     );
+
+    client.close()
   });
 
   it('should succeed with full signatures', async () => {
@@ -137,6 +140,8 @@ describe('a check with an known namespace', () => {
     expect(checkResponse?.permissionship).toBe(
       CheckPermissionResponse_Permissionship.HAS_PERMISSION
     );
+
+    client.close()
   })
 });
 
@@ -231,7 +236,8 @@ describe('Lookup APIs', () => {
       ],
     });
 
-    return client.writeRelationships(writeRequest)
+    await client.writeRelationships(writeRequest)
+    client.close()
   });
 
   it('can lookup subjects', async () => {
@@ -243,6 +249,7 @@ describe('Lookup APIs', () => {
 
     const result = await client.lookupSubjects(lookupSubjectRequest)
     expect(['someuser', 'someuser2']).toContain(result[0].subjectObjectId);
+    client.close()
   });
 
   it('can lookup resources', async () => {
@@ -254,6 +261,8 @@ describe('Lookup APIs', () => {
 
     const resStream = await client.lookupResources(lookupResourceRequest)
     expect(resStream[0].resourceObjectId).toEqual('somedocument');
+
+    client.close()
   });
 
   it('can lookup using full signatures', async () => {
@@ -268,5 +277,7 @@ describe('Lookup APIs', () => {
 
     const resStream = await client.lookupResources(lookupResourceRequest, new grpc.Metadata(), {} as grpc.CallOptions)
     expect(resStream[0].resourceObjectId).toEqual('somedocument');
+
+    client.close()
   })
 });

--- a/src/v1.test.ts
+++ b/src/v1.test.ts
@@ -49,6 +49,7 @@ describe('a check with an unknown namespace', () => {
     client.checkPermission(checkPermissionRequest, function (err, response) {
       expect(response).toBe(undefined);
       expect(err?.code).toBe(grpc.status.FAILED_PRECONDITION);
+      client.close()
       done();
     });
   });
@@ -154,6 +155,7 @@ describe('a check with an known namespace', () => {
           CheckPermissionResponse_Permissionship.HAS_PERMISSION
         );
 
+        client.close()
         done();
       });
   });
@@ -259,10 +261,12 @@ describe('Lookup APIs', () => {
     });
 
     resStream.on('end', function () {
+      client.close()
       done();
     });
 
     resStream.on('error', function (e) {
+      client.close()
       done.fail(e);
     });
 
@@ -302,10 +306,12 @@ describe('Lookup APIs', () => {
     });
 
     resStream.on('end', function () {
+      client.close()
       done();
     });
 
     resStream.on('error', function (e) {
+      client.close()
       done.fail(e);
     });
 


### PR DESCRIPTION
The `close` method of the grpc.Client does not correctly get proxied to each individual gRPC client that we are creating in the composite client. This PR updates the interface/proxy logic to correctly proxy the `close` method to a function that will close all known clients.