### PR TITLE
Update node client to SpiceDB 1.25.0

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S buf generate buf.build/authzed/api:206ed0aae546729d1bba96f506972b78eab4feeb --template
+#!/usr/bin/env -S buf generate buf.build/authzed/api:ae0019fd4971464faeac85b2e146bdb8 --template
 # To regenerate:
 #   npm install -g grpc-tools
 #   ./buf.gen.yaml

--- a/src/authzedapi/authzed/api/v1/experimental_service.grpc-client.ts
+++ b/src/authzedapi/authzed/api/v1/experimental_service.grpc-client.ts
@@ -6,8 +6,6 @@ import type { BinaryWriteOptions } from "@protobuf-ts/runtime";
 import type { BinaryReadOptions } from "@protobuf-ts/runtime";
 import type { BulkCheckPermissionResponse } from "./experimental_service";
 import type { BulkCheckPermissionRequest } from "./experimental_service";
-import type { StreamingBulkCheckPermissionResponse } from "./experimental_service";
-import type { StreamingBulkCheckPermissionRequest } from "./experimental_service";
 import type { BulkExportRelationshipsResponse } from "./experimental_service";
 import type { BulkExportRelationshipsRequest } from "./experimental_service";
 import type { BulkImportRelationshipsRequest } from "./experimental_service";
@@ -46,11 +44,6 @@ export interface IExperimentalServiceClient {
      */
     bulkExportRelationships(input: BulkExportRelationshipsRequest, metadata?: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientReadableStream<BulkExportRelationshipsResponse>;
     bulkExportRelationships(input: BulkExportRelationshipsRequest, options?: grpc.CallOptions): grpc.ClientReadableStream<BulkExportRelationshipsResponse>;
-    /**
-     * @generated from protobuf rpc: StreamingBulkCheckPermission(authzed.api.v1.StreamingBulkCheckPermissionRequest) returns (stream authzed.api.v1.StreamingBulkCheckPermissionResponse);
-     */
-    streamingBulkCheckPermission(input: StreamingBulkCheckPermissionRequest, metadata?: grpc.Metadata, options?: grpc.CallOptions): grpc.ClientReadableStream<StreamingBulkCheckPermissionResponse>;
-    streamingBulkCheckPermission(input: StreamingBulkCheckPermissionRequest, options?: grpc.CallOptions): grpc.ClientReadableStream<StreamingBulkCheckPermissionResponse>;
     /**
      * @generated from protobuf rpc: BulkCheckPermission(authzed.api.v1.BulkCheckPermissionRequest) returns (authzed.api.v1.BulkCheckPermissionResponse);
      */
@@ -100,17 +93,10 @@ export class ExperimentalServiceClient extends grpc.Client implements IExperimen
         return this.makeServerStreamRequest<BulkExportRelationshipsRequest, BulkExportRelationshipsResponse>(`/${ExperimentalService.typeName}/${method.name}`, (value: BulkExportRelationshipsRequest): Buffer => Buffer.from(method.I.toBinary(value, this._binaryOptions)), (value: Buffer): BulkExportRelationshipsResponse => method.O.fromBinary(value, this._binaryOptions), input, (metadata as any), options);
     }
     /**
-     * @generated from protobuf rpc: StreamingBulkCheckPermission(authzed.api.v1.StreamingBulkCheckPermissionRequest) returns (stream authzed.api.v1.StreamingBulkCheckPermissionResponse);
-     */
-    streamingBulkCheckPermission(input: StreamingBulkCheckPermissionRequest, metadata?: grpc.Metadata | grpc.CallOptions, options?: grpc.CallOptions): grpc.ClientReadableStream<StreamingBulkCheckPermissionResponse> {
-        const method = ExperimentalService.methods[2];
-        return this.makeServerStreamRequest<StreamingBulkCheckPermissionRequest, StreamingBulkCheckPermissionResponse>(`/${ExperimentalService.typeName}/${method.name}`, (value: StreamingBulkCheckPermissionRequest): Buffer => Buffer.from(method.I.toBinary(value, this._binaryOptions)), (value: Buffer): StreamingBulkCheckPermissionResponse => method.O.fromBinary(value, this._binaryOptions), input, (metadata as any), options);
-    }
-    /**
      * @generated from protobuf rpc: BulkCheckPermission(authzed.api.v1.BulkCheckPermissionRequest) returns (authzed.api.v1.BulkCheckPermissionResponse);
      */
     bulkCheckPermission(input: BulkCheckPermissionRequest, metadata: grpc.Metadata | grpc.CallOptions | ((err: grpc.ServiceError | null, value?: BulkCheckPermissionResponse) => void), options?: grpc.CallOptions | ((err: grpc.ServiceError | null, value?: BulkCheckPermissionResponse) => void), callback?: ((err: grpc.ServiceError | null, value?: BulkCheckPermissionResponse) => void)): grpc.ClientUnaryCall {
-        const method = ExperimentalService.methods[3];
+        const method = ExperimentalService.methods[2];
         return this.makeUnaryRequest<BulkCheckPermissionRequest, BulkCheckPermissionResponse>(`/${ExperimentalService.typeName}/${method.name}`, (value: BulkCheckPermissionRequest): Buffer => Buffer.from(method.I.toBinary(value, this._binaryOptions)), (value: Buffer): BulkCheckPermissionResponse => method.O.fromBinary(value, this._binaryOptions), input, (metadata as any), (options as any), (callback as any));
     }
 }

--- a/src/authzedapi/authzed/api/v1/experimental_service.ts
+++ b/src/authzedapi/authzed/api/v1/experimental_service.ts
@@ -23,19 +23,6 @@ import { SubjectReference } from "./core";
 import { ObjectReference } from "./core";
 import { Consistency } from "./permission_service";
 /**
- * @generated from protobuf message authzed.api.v1.StreamingBulkCheckPermissionRequest
- */
-export interface StreamingBulkCheckPermissionRequest {
-    /**
-     * @generated from protobuf field: authzed.api.v1.Consistency consistency = 1;
-     */
-    consistency?: Consistency;
-    /**
-     * @generated from protobuf field: repeated authzed.api.v1.BulkCheckPermissionRequestItem items = 2;
-     */
-    items: BulkCheckPermissionRequestItem[];
-}
-/**
  * @generated from protobuf message authzed.api.v1.BulkCheckPermissionRequest
  */
 export interface BulkCheckPermissionRequest {
@@ -73,19 +60,6 @@ export interface BulkCheckPermissionRequestItem {
  * @generated from protobuf message authzed.api.v1.BulkCheckPermissionResponse
  */
 export interface BulkCheckPermissionResponse {
-    /**
-     * @generated from protobuf field: authzed.api.v1.ZedToken checked_at = 1;
-     */
-    checkedAt?: ZedToken;
-    /**
-     * @generated from protobuf field: repeated authzed.api.v1.BulkCheckPermissionPair pairs = 2;
-     */
-    pairs: BulkCheckPermissionPair[];
-}
-/**
- * @generated from protobuf message authzed.api.v1.StreamingBulkCheckPermissionResponse
- */
-export interface StreamingBulkCheckPermissionResponse {
     /**
      * @generated from protobuf field: authzed.api.v1.ZedToken checked_at = 1;
      */
@@ -208,60 +182,6 @@ export interface BulkExportRelationshipsResponse {
      */
     relationships: Relationship[];
 }
-// @generated message type with reflection information, may provide speed optimized methods
-class StreamingBulkCheckPermissionRequest$Type extends MessageType<StreamingBulkCheckPermissionRequest> {
-    constructor() {
-        super("authzed.api.v1.StreamingBulkCheckPermissionRequest", [
-            { no: 1, name: "consistency", kind: "message", T: () => Consistency },
-            { no: 2, name: "items", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => BulkCheckPermissionRequestItem, options: { "validate.rules": { repeated: { items: { message: { required: true } } } } } }
-        ]);
-    }
-    create(value?: PartialMessage<StreamingBulkCheckPermissionRequest>): StreamingBulkCheckPermissionRequest {
-        const message = { items: [] };
-        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
-        if (value !== undefined)
-            reflectionMergePartial<StreamingBulkCheckPermissionRequest>(this, message, value);
-        return message;
-    }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: StreamingBulkCheckPermissionRequest): StreamingBulkCheckPermissionRequest {
-        let message = target ?? this.create(), end = reader.pos + length;
-        while (reader.pos < end) {
-            let [fieldNo, wireType] = reader.tag();
-            switch (fieldNo) {
-                case /* authzed.api.v1.Consistency consistency */ 1:
-                    message.consistency = Consistency.internalBinaryRead(reader, reader.uint32(), options, message.consistency);
-                    break;
-                case /* repeated authzed.api.v1.BulkCheckPermissionRequestItem items */ 2:
-                    message.items.push(BulkCheckPermissionRequestItem.internalBinaryRead(reader, reader.uint32(), options));
-                    break;
-                default:
-                    let u = options.readUnknownField;
-                    if (u === "throw")
-                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
-                    let d = reader.skip(wireType);
-                    if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
-            }
-        }
-        return message;
-    }
-    internalBinaryWrite(message: StreamingBulkCheckPermissionRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* authzed.api.v1.Consistency consistency = 1; */
-        if (message.consistency)
-            Consistency.internalBinaryWrite(message.consistency, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
-        /* repeated authzed.api.v1.BulkCheckPermissionRequestItem items = 2; */
-        for (let i = 0; i < message.items.length; i++)
-            BulkCheckPermissionRequestItem.internalBinaryWrite(message.items[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        let u = options.writeUnknownFields;
-        if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
-        return writer;
-    }
-}
-/**
- * @generated MessageType for protobuf message authzed.api.v1.StreamingBulkCheckPermissionRequest
- */
-export const StreamingBulkCheckPermissionRequest = new StreamingBulkCheckPermissionRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class BulkCheckPermissionRequest$Type extends MessageType<BulkCheckPermissionRequest> {
     constructor() {
@@ -438,60 +358,6 @@ class BulkCheckPermissionResponse$Type extends MessageType<BulkCheckPermissionRe
  * @generated MessageType for protobuf message authzed.api.v1.BulkCheckPermissionResponse
  */
 export const BulkCheckPermissionResponse = new BulkCheckPermissionResponse$Type();
-// @generated message type with reflection information, may provide speed optimized methods
-class StreamingBulkCheckPermissionResponse$Type extends MessageType<StreamingBulkCheckPermissionResponse> {
-    constructor() {
-        super("authzed.api.v1.StreamingBulkCheckPermissionResponse", [
-            { no: 1, name: "checked_at", kind: "message", T: () => ZedToken, options: { "validate.rules": { message: { required: false } } } },
-            { no: 2, name: "pairs", kind: "message", repeat: 1 /*RepeatType.PACKED*/, T: () => BulkCheckPermissionPair, options: { "validate.rules": { repeated: { items: { message: { required: true } } } } } }
-        ]);
-    }
-    create(value?: PartialMessage<StreamingBulkCheckPermissionResponse>): StreamingBulkCheckPermissionResponse {
-        const message = { pairs: [] };
-        globalThis.Object.defineProperty(message, MESSAGE_TYPE, { enumerable: false, value: this });
-        if (value !== undefined)
-            reflectionMergePartial<StreamingBulkCheckPermissionResponse>(this, message, value);
-        return message;
-    }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: StreamingBulkCheckPermissionResponse): StreamingBulkCheckPermissionResponse {
-        let message = target ?? this.create(), end = reader.pos + length;
-        while (reader.pos < end) {
-            let [fieldNo, wireType] = reader.tag();
-            switch (fieldNo) {
-                case /* authzed.api.v1.ZedToken checked_at */ 1:
-                    message.checkedAt = ZedToken.internalBinaryRead(reader, reader.uint32(), options, message.checkedAt);
-                    break;
-                case /* repeated authzed.api.v1.BulkCheckPermissionPair pairs */ 2:
-                    message.pairs.push(BulkCheckPermissionPair.internalBinaryRead(reader, reader.uint32(), options));
-                    break;
-                default:
-                    let u = options.readUnknownField;
-                    if (u === "throw")
-                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
-                    let d = reader.skip(wireType);
-                    if (u !== false)
-                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
-            }
-        }
-        return message;
-    }
-    internalBinaryWrite(message: StreamingBulkCheckPermissionResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* authzed.api.v1.ZedToken checked_at = 1; */
-        if (message.checkedAt)
-            ZedToken.internalBinaryWrite(message.checkedAt, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
-        /* repeated authzed.api.v1.BulkCheckPermissionPair pairs = 2; */
-        for (let i = 0; i < message.pairs.length; i++)
-            BulkCheckPermissionPair.internalBinaryWrite(message.pairs[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        let u = options.writeUnknownFields;
-        if (u !== false)
-            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
-        return writer;
-    }
-}
-/**
- * @generated MessageType for protobuf message authzed.api.v1.StreamingBulkCheckPermissionResponse
- */
-export const StreamingBulkCheckPermissionResponse = new StreamingBulkCheckPermissionResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class BulkCheckPermissionPair$Type extends MessageType<BulkCheckPermissionPair> {
     constructor() {
@@ -828,6 +694,5 @@ export const BulkExportRelationshipsResponse = new BulkExportRelationshipsRespon
 export const ExperimentalService = new ServiceType("authzed.api.v1.ExperimentalService", [
     { name: "BulkImportRelationships", clientStreaming: true, options: { "google.api.http": { post: "/v1/experimental/relationships/bulkimport", body: "*" } }, I: BulkImportRelationshipsRequest, O: BulkImportRelationshipsResponse },
     { name: "BulkExportRelationships", serverStreaming: true, options: { "google.api.http": { post: "/v1/experimental/relationships/bulkexport", body: "*" } }, I: BulkExportRelationshipsRequest, O: BulkExportRelationshipsResponse },
-    { name: "StreamingBulkCheckPermission", serverStreaming: true, options: { "google.api.http": { post: "/v1/experimental/permissions/streamingbulkcheckpermission", body: "*" } }, I: StreamingBulkCheckPermissionRequest, O: StreamingBulkCheckPermissionResponse },
     { name: "BulkCheckPermission", options: { "google.api.http": { post: "/v1/experimental/permissions/bulkcheckpermission", body: "*" } }, I: BulkCheckPermissionRequest, O: BulkCheckPermissionResponse }
 ]);

--- a/src/authzedapi/authzed/api/v1/schema_service.ts
+++ b/src/authzedapi/authzed/api/v1/schema_service.ts
@@ -53,7 +53,7 @@ export interface WriteSchemaRequest {
      *
      * @generated from protobuf field: string schema = 1;
      */
-    schema: string; // 256KiB
+    schema: string; // 4MiB
 }
 /**
  * WriteSchemaResponse is the resulting data after having written a Schema to
@@ -153,7 +153,7 @@ export const ReadSchemaResponse = new ReadSchemaResponse$Type();
 class WriteSchemaRequest$Type extends MessageType<WriteSchemaRequest> {
     constructor() {
         super("authzed.api.v1.WriteSchemaRequest", [
-            { no: 1, name: "schema", kind: "scalar", T: 9 /*ScalarType.STRING*/, options: { "validate.rules": { string: { maxBytes: "262144" } } } }
+            { no: 1, name: "schema", kind: "scalar", T: 9 /*ScalarType.STRING*/, options: { "validate.rules": { string: { maxBytes: "4194304" } } } }
         ]);
     }
     create(value?: PartialMessage<WriteSchemaRequest>): WriteSchemaRequest {


### PR DESCRIPTION
The client hasn't been updated for a while and we'd like to be able to use the batch permissions