### PR TITLE
triggers builds if github event is release

### DIFF
--- a/.github/workflows/authzed-node.yaml
+++ b/.github/workflows/authzed-node.yaml
@@ -35,7 +35,7 @@ jobs:
         node-version: [18, 20, 21]
     needs: "paths-filter"
     if: |
-      needs.paths-filter.outputs.codechange == 'true'
+      needs.paths-filter.outputs.codechange == 'true' || github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4
       - uses: "authzed/action-spicedb@v1"
@@ -81,7 +81,7 @@ jobs:
         node-version: [18, 20, 21]
     needs: "paths-filter"
     if: |
-      needs.paths-filter.outputs.codechange == 'true'
+      needs.paths-filter.outputs.codechange == 'true' || github.event_name == 'release'
     steps:
       - uses: actions/checkout@v4
       - uses: "authzed/action-spicedb@v1"


### PR DESCRIPTION
recent changes to bypass CI builds when
code unrelated changes happen broke
the release process, because the release
jobs have those bypassed builds as required.

this changes the bypass condition so that
they run if the event that triggered
GitHub Actions was a release