### PR TITLE
Use script instead of abandoned lib

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,9 +16,13 @@ jobs:
           node-version: 18
       - uses: bahmutov/npm-install@v1
       - run: yarn test
-      - uses: battila7/get-version-action@v2
       # Set the version in package.json to match the tag
-      - run: "npm version ${{ steps.get_version.outputs.version-without-v }}"
+      - name: Write release version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - run: "npm version ${VERSION}"
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
@@ -41,9 +45,13 @@ jobs:
       - uses: bahmutov/npm-install@v1
         with:
           working-directory: ./js-dist
-      - uses: battila7/get-version-action@v2
+      - name: Write release version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
       # Set the version in package.json to match the tag
-      - run: "npm version ${{ steps.get_version.outputs.version-without-v }}"
+      - run: "npm version ${VERSION}"
         working-directory: ./js-dist
       - uses: JS-DevTools/npm-publish@v3
         with:


### PR DESCRIPTION
## Description
I went and checked the npm registry and the version wasn't v1.0.1. The version getting step didn't work as desired, so the version setting step was a read-only step rather than something that set the version. This fixes that.

The version getting action is 3 years out of date at this point, so we're using a script instead of it.

## Changes
* Use the script approach that works in other libs

## Testing
Release and see that the version appears on npm.