### PR TITLE
Fix npm version invocation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,13 +2,9 @@
 # yamllint disable rule:line-length
 name: "Publish to NPM"
 on:  # yamllint disable-line rule:truthy
-  #release:
-    #types:
-      #- "published"
-  # NOTE: this is temporary until I get the release process ironed out.
-  pull_request:
-    branches:
-      - "*"
+  release:
+    types:
+      - "published"
 
 jobs:
   publish:
@@ -20,7 +16,6 @@ jobs:
         with:
           node-version: 18
       - uses: bahmutov/npm-install@v1
-      - run: yarn test
       # Set the version in package.json to match the tag
       - name: Write release version
         run: |
@@ -29,7 +24,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       # NOTE: the flag is necessary because otherwise `npm version <version>` attempts to
       # cut a git tag with that version, which fails because the git user isn't configured.
-      - run: "npm version 1.0.2 --no-git-tag-version"
+      - run: "npm version ${VERSION} --no-git-tag-version"
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
@@ -60,7 +55,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       # NOTE: the flag is necessary because otherwise `npm version <version>` attempts to
       # cut a git tag with that version, which fails because the git user isn't configured.
-      - run: "npm version 1.0.2 --no-git-tag-version"
+      - run: "npm version ${VERSION} --no-git-tag-version"
         working-directory: ./js-dist
       - uses: JS-DevTools/npm-publish@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,9 +2,14 @@
 # yamllint disable rule:line-length
 name: "Publish to NPM"
 on:  # yamllint disable-line rule:truthy
-  release:
-    types:
-      - "published"
+  #release:
+    #types:
+      #- "published"
+  # NOTE: this is temporary until I get the release process ironed out.
+  pull_request:
+    branches:
+      - "*"
+
 jobs:
   publish:
     name: Publish to NPM
@@ -22,7 +27,9 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           echo Version: $VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      - run: "npm version ${VERSION}"
+      # NOTE: the flag is necessary because otherwise `npm version <version>` attempts to
+      # cut a git tag with that version, which fails because the git user isn't configured.
+      - run: "npm version 1.0.2 --no-git-tag-version"
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
@@ -45,13 +52,15 @@ jobs:
       - uses: bahmutov/npm-install@v1
         with:
           working-directory: ./js-dist
+      # Set the version in package.json to match the tag
       - name: Write release version
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo Version: $VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-      # Set the version in package.json to match the tag
-      - run: "npm version ${VERSION}"
+      # NOTE: the flag is necessary because otherwise `npm version <version>` attempts to
+      # cut a git tag with that version, which fails because the git user isn't configured.
+      - run: "npm version 1.0.2 --no-git-tag-version"
         working-directory: ./js-dist
       - uses: JS-DevTools/npm-publish@v3
         with:


### PR DESCRIPTION
## Description
Turns out `npm version <version>` tries to commit a tag. We don't want that in this context, and it causes failures.

I also am taking a different approach to fixing the release process - this should mean that I don't need to keep cutting releases until I get the process sorted.

## Changes
* Fix `npm version` invocation
### Temp
* Change publish to run on PR
## Testing
See that publish step completes. Then I'll revert the changes to the workflow triggers and we can merge.