### PR TITLE
Use remotes for code generation and update regen workflows accordingly

### DIFF
--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -1,7 +1,7 @@
-name: Called update for API change
+name: "Called update for API change"
 on:
   repository_dispatch:
-    types: [api_update]
+    types: ["api_update"]
 jobs:
   test:
     name: "Create PR for API update"
@@ -14,48 +14,28 @@ jobs:
         id: buf-update
         uses: authzed/actions/buf-api-update@main
         with:
-          api-commit: ${{ github.event.client_payload.BUFTAG }}
+          api-commit: "${{ github.event.client_payload.BUFTAG }}"
           spec-path: buf.gen.yaml
-          file-format: generate-shell-script
+          file-format: "buf-gen-yaml"
       - name: "Output update status"
         env:
           UPDATED_STATUS: ${{ steps.buf-update.outputs.updated }}
         run: |
           echo "Update status: $UPDATED_STATUS"
-      - name: "Update package version"
-        uses: authzed/actions/semver-update@main
-        if: steps.buf-update.outputs.updated == 'true'
-        with:
-          sourcefile-path: package.json
-          version-regex: '"version": "(.+)"'
-          version-change: minor
-      - name: "Update js-dist package version"
-        uses: authzed/actions/semver-update@main
-        if: steps.buf-update.outputs.updated == 'true'
-        with:
-          sourcefile-path: js-dist/package.json
-          version-regex: '"version": "(.+)"'
-          version-change: minor
-      - name: "Install NPM deps"
-        uses: bahmutov/npm-install@v1
-        if: steps.buf-update.outputs.updated == 'true'
-        with:
-          useLockFile: false
-          working-directory: ./
       - name: "Install buf"
-        uses: "bufbuild/buf-setup-action@v1.46.0"
-        if: steps.buf-update.outputs.updated == 'true'
+        uses: "bufbuild/buf-setup-action@v1.43.0"
         with:
-          version: "1.37.0"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.buf-update.outputs.updated == 'true'
       - name: "Run buf generate"
         if: steps.buf-update.outputs.updated == 'true'
-        run: |
-          ./buf.gen.yaml
+        run: "buf generate"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.5
         if: steps.buf-update.outputs.updated == 'true'
         with:
           delete-branch: "true"
-          title: Update API to ${{ github.event.client_payload.BUFTAG }}
-          branch: api-change/${{ github.event.client_payload.BUFTAG }}
+          title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          branch: "api-change/${{ github.event.client_payload.BUFTAG }}"
+          base: "main"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -1,3 +1,4 @@
+---
 name: Update for API change
 on:
   workflow_dispatch:
@@ -20,41 +21,20 @@ jobs:
         with:
           api-commit: ${{ inputs.buftag }}
           spec-path: buf.gen.yaml
-          file-format: generate-shell-script
+          file-format: "buf-gen-yaml"
       - name: "Output update status"
         env:
           UPDATED_STATUS: ${{ steps.buf-update.outputs.updated }}
         run: |
           echo "Update status: $UPDATED_STATUS"
-      - name: "Update package version"
-        uses: authzed/actions/semver-update@main
-        if: steps.buf-update.outputs.updated == 'true'
-        with:
-          sourcefile-path: package.json
-          version-regex: '"version": "(.+)"'
-          version-change: minor
-      - name: "Update js-dist package version"
-        uses: authzed/actions/semver-update@main
-        if: steps.buf-update.outputs.updated == 'true'
-        with:
-          sourcefile-path: js-dist/package.json
-          version-regex: '"version": "(.+)"'
-          version-change: minor
-      - name: "Install NPM deps"
-        uses: bahmutov/npm-install@v1
-        if: steps.buf-update.outputs.updated == 'true'
-        with:
-          useLockFile: false
-          working-directory: ./
       - name: "Install buf"
-        uses: "bufbuild/buf-setup-action@v1.46.0"
-        if: steps.buf-update.outputs.updated == 'true'
+        uses: "bufbuild/buf-setup-action@v1.43.0"
         with:
-          version: "1.37.0"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.buf-update.outputs.updated == 'true'
       - name: "Run buf generate"
         if: steps.buf-update.outputs.updated == 'true'
-        run: |
-          ./buf.gen.yaml
+        run: "buf generate"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7.0.5
         if: steps.buf-update.outputs.updated == 'true'
@@ -62,4 +42,5 @@ jobs:
           delete-branch: "true"
           title: Update API to ${{ inputs.buftag }}
           branch: api-change/${{ inputs.buftag }}
+          base: "main"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,10 +1,8 @@
-#!/usr/bin/env -S buf generate buf.build/authzed/api:v1.38.0 --template
-# To regenerate:
-#   npm install -g grpc-tools
-#   ./buf.gen.yaml
-version: "v1beta1"
+---
+version: "v2"
 plugins:
-  - name: "ts"
+  - remote: buf.build/community/timostamm-protobuf-ts:v2.9.4
     out: "src/authzedapi"
     opt: generate_dependencies,long_type_string,client_grpc1
-    path: ./node_modules/@protobuf-ts/plugin/bin/protoc-gen-ts
+inputs:
+  - module: "buf.build/authzed/api:v1.38.0"


### PR DESCRIPTION
## Description
Part of getting all of our various libraries migrated

## Note
I ran `buf generate` as a part of this PR and there were no changes, which seems like a good sign.

## Changes
* Use v2 of buf.gen.yaml
* Use new actions for API version update

## Testing
Review. See that things are green.