### PR TITLE
Add new bulk functions to list of stream endpoints

### DIFF
--- a/src/v1.ts
+++ b/src/v1.ts
@@ -201,8 +201,9 @@ class ZedPromiseClient implements ProxyHandler<ZedPromiseClientInterface> {
     'lookupResources',
     'lookupSubjects',
     'bulkExportRelationships',
+    'exportBulkRelationships',
   ]);
-  private writableStreamMethods = new Set(['bulkImportRelationships']);
+  private writableStreamMethods = new Set(['bulkImportRelationships', 'importBulkRelationships']);
 
   constructor(client: ZedDefaultClientInterface) {
     this.client = client;


### PR DESCRIPTION
Fixes #170 

## Description
As currently written, the client decides which functions to wrap with promises based on a list of streaming endpoints in the client. When we added the new versions of `importBulk` and `exportBulk`, we didn't add them to this list, which caused the behavior seen in #170. This is a short-term fix for that. A longer-term fix would be something like #179.

## Changes
* Add new methods to list of streaming methods

## Testing
Review.