### PR TITLE
Fix bulk check typing issue

### DIFF
--- a/src/__utils__/helpers.ts
+++ b/src/__utils__/helpers.ts
@@ -1,9 +1,119 @@
+import {
+    ClientSecurity,
+    NewClient,
+    ZedClientInterface,
+    RelationshipUpdate_Operation,
+} from '../v1.js'
+
 /**
- * Generates a random token with a prefix to support
- * unique, idempotent local testing.
- * @param prefix 
- * @returns 
+ * Generates a random token to support unique, idempotent local testing.
  */
-export function generateTestToken(prefix: string): string {
-  return `${prefix}-${Date.now().toString()}`
+export function generateTestToken(): string {
+  return Math.random().toString()
+}
+
+/*
+ * Asserts that a value or expression is non-falsey.
+ * It's mostly useful to use a statement to narrow a type
+ * (as opposed to using an if statement, which is annoying
+ * in tests)
+ */
+export function assert(val: unknown, msg = "Assertion failed"): asserts val {
+  if(!val) throw new Error(msg);
+}
+
+export const testClient = () => NewClient(
+      generateTestToken(),
+      'localhost:50051',
+      ClientSecurity.INSECURE_LOCALHOST_ALLOWED
+    )
+
+const testSchema = `
+caveat likes_harry_potter(likes bool) {
+  likes == true
+}
+
+definition post {
+    relation writer: user
+    relation reader: user
+    relation caveated_reader: user with likes_harry_potter
+
+    permission write = writer
+    permission view = reader + writer
+    permission view_as_fan = caveated_reader + writer
+}
+definition user {}
+`
+
+export const writeTestSchema = async (client: ZedClientInterface) => {
+    await client.promises.writeSchema({
+        schema: testSchema
+    })
+}
+
+export const writeTestTuples = async (client: ZedClientInterface) => {
+    const emilia = {
+        object: {
+            objectType: "user",
+            objectId: "emilia"
+        },
+        optionalRelation: "",
+    }
+    const beatrice = {
+        object: {
+            objectType: "user",
+            objectId: "beatrice"
+        },
+        optionalRelation: "",
+    }
+    const postOne = {
+        objectType: "post",
+        objectId: "post-one"
+    }
+    const postTwo = {
+        objectType: "post",
+        objectId: "post-two"
+    }
+    await client.promises.writeRelationships({
+        // NOTE: optionalPreconditions seems like it should be omittable,
+        // but the way that the typescript plugin handles repeated fields
+        // is to treat them as required.
+        optionalPreconditions: [],
+        updates: [
+            {
+                operation: RelationshipUpdate_Operation.CREATE,
+                relationship: {
+                    subject: emilia,
+                    relation: "writer",
+                    resource: postOne,
+                }
+            },
+            {
+                operation: RelationshipUpdate_Operation.CREATE,
+                relationship: {
+                    subject: emilia,
+                    relation: "writer",
+                    resource: postTwo,
+                }
+            },
+            {
+                operation: RelationshipUpdate_Operation.CREATE,
+                relationship: {
+                    subject: beatrice,
+                    relation: "reader",
+                    resource: postOne,
+                }
+            },
+            {
+                operation: RelationshipUpdate_Operation.CREATE,
+                relationship: {
+                    subject: beatrice,
+                    relation: "caveated_reader",
+                    resource: postOne,
+                    optionalCaveat: { caveatName: "likes_harry_potter" }
+                }
+            },
+        ]
+    })
+    return { emilia, beatrice, postOne, postTwo };
 }

--- a/src/v1.test.ts
+++ b/src/v1.test.ts
@@ -49,7 +49,7 @@ describe("a check with an unknown namespace", () => {
     });
 
     const client = NewClient(
-      generateTestToken("v1-test-unknown"),
+      generateTestToken(),
       "localhost:50051",
       ClientSecurity.INSECURE_LOCALHOST_ALLOWED
     );
@@ -66,7 +66,7 @@ describe("a check with an known namespace", () => {
   it("should succeed", () => new Promise<void>((done) => {
     // Write some schema.
     const client = NewClient(
-      generateTestToken("v1-namespace"),
+      generateTestToken(),
       "localhost:50051",
       ClientSecurity.INSECURE_LOCALHOST_ALLOWED,
       PreconnectServices.PERMISSIONS_SERVICE | PreconnectServices.SCHEMA_SERVICE
@@ -172,7 +172,7 @@ describe("a check with an known namespace", () => {
     it("should succeed", () => new Promise<void>((done) => {
       // Write some schema.
       const client = NewClient(
-        generateTestToken("v1-namespace-caveats"),
+        generateTestToken(),
         "localhost:50051",
         ClientSecurity.INSECURE_LOCALHOST_ALLOWED
       );
@@ -288,7 +288,7 @@ describe("Lookup APIs", () => {
   let token: string;
 
   beforeEach(() => new Promise<void>((done) => {
-    token = generateTestToken("v1-lookup");
+    token = generateTestToken();
     const client = NewClient(
       token,
       "localhost:50051",
@@ -461,7 +461,7 @@ describe("a check with a negative timeout", () => {
     });
 
     const client = NewClient(
-      generateTestToken("v1-test-unknown"),
+      generateTestToken(),
       "localhost:50051",
       ClientSecurity.INSECURE_LOCALHOST_ALLOWED,
       PreconnectServices.NONE,
@@ -482,7 +482,7 @@ describe("Experimental Service", () => {
   let token: string;
 
   beforeEach(() => new Promise<void>((done) => {
-    token = generateTestToken("v1-experimental-service");
+    token = generateTestToken();
     const client = NewClient(
       token,
       "localhost:50051",


### PR DESCRIPTION
Fixes #187

## Note
This is not yet a solution to the problem, but it is a test that demonstrates the problem.

## Description
As seen in #187, promisified clients have the wrong types, which means that they disagree with the runtime about the correct invocation. This is likely in part due to how we're typing the promisified clients, and in part due to the clients having multiple overloads for the generated methods.

## Changes
* Add some test utilities
* Add a test that demonstrates the issue

## Testing
Review.