### PR TITLE
Update triggered PRs to be drafts

### DIFF
--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -40,6 +40,8 @@ jobs:
         with:
           delete-branch: "true"
           title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          draft: "always-true"
           branch: "api-change/${{ github.event.client_payload.BUFTAG }}"
           base: "main"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,3 +1,4 @@
+---
 name: "CLA"
 on:  # yamllint disable-line rule:truthy
   issue_comment:

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -41,6 +41,8 @@ jobs:
         with:
           delete-branch: "true"
           title: Update API to ${{ inputs.buftag }}
+          # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+          draft: "always-true"
           branch: api-change/${{ inputs.buftag }}
           base: "main"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Part of making API updates an easier process. This makes the created PRs into drafts, which ensures that tests run when we move them out of draft.

## Changes
* Add always draft setting

## Testing
Review.