### PR TITLE
Run tests against Node 22

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: "buildjet-2vcpu-ubuntu-2204"
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: [18, 20, 22]
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'
@@ -55,7 +55,7 @@ jobs:
     runs-on: "buildjet-2vcpu-ubuntu-2204"
     strategy:
       matrix:
-        node-version: [18, 20, 21]
+        node-version: [18, 20, 22]
     needs: "paths-filter"
     if: |
       needs.paths-filter.outputs.codechange == 'true'

--- a/README.md
+++ b/README.md
@@ -142,6 +142,6 @@ console.log(results[0]); // first ReadRelationship result
 
 ## Requirements
 
-Supported Node.js versions: 18, 20, 21
+Supported Node.js versions: 18, 20, 22
 
 Minimum TypeScript version 3.8


### PR DESCRIPTION
Fixes #193 
## Description
Node 22 is the current LTS, and odd-numbered node versions are never LTS. We're probably okay to run only against even-numbered versions.

## Changes
* Run against node 22 instead of node 21

## Testing
See that tests pass with new matrix