### PR TITLE
Pin grpc-js temporarily to work around issue

### DIFF
--- a/js-dist/package.json
+++ b/js-dist/package.json
@@ -22,7 +22,7 @@
     "only-run-tests": "vitest"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.11.3",
+    "@grpc/grpc-js": "~1.12.5",
     "google-protobuf": "^3.15.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build-js-client": "tsc --declaration false --outDir js-dist"
   },
   "dependencies": {
-    "@grpc/grpc-js": "^1.12.5",
+    "@grpc/grpc-js": "~1.12.5",
     "@protobuf-ts/runtime": "^2.9.4",
     "@protobuf-ts/runtime-rpc": "^2.9.4",
     "google-protobuf": "^3.21.4"


### PR DESCRIPTION
Part of #206 
## Description
Users reported breakage of the `authzed-node` lib related to our `KnownInsecureChannelCredentials` implementation (see issue for details). This appears to be related to the v1.13.0 or v1.13.1 release of grpc-js, though it's unclear what part of those releases would be related.

## Changes
* Pin grpc-js temporarily to v1.12.x (using `~` instead of `^`)
## Testing
Review. See that tests pass.