### PR TITLE
util: fix util for changes to `channel-credentials.ts` in grpc-js

### DIFF
--- a/examples/v1/example.js
+++ b/examples/v1/example.js
@@ -1,8 +1,8 @@
 import { v1 } from '@authzed/authzed-node';
-const { promises: promiseClient } = client; // access client.promises
 // set up it on localhost like this:
 // const client = v1.NewClient('mytokenhere', 'localhost:50051', 1);
 const client = v1.NewClient('mytokenhere');
+const { promises: promiseClient } = client; // access client.promises after instantiating client
 
 const writeRequest = v1.WriteSchemaRequest.create({
   schema: `definition test/user {}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build-js-client": "tsc --declaration false --outDir js-dist"
   },
   "dependencies": {
-    "@grpc/grpc-js": "~1.12.5",
+    "@grpc/grpc-js": "^1.12.5",
     "@protobuf-ts/runtime": "^2.9.6",
     "@protobuf-ts/runtime-rpc": "^2.9.6",
     "google-protobuf": "^3.21.4"

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,19 +1,21 @@
 import * as grpc from "@grpc/grpc-js";
 import { NextCall } from "@grpc/grpc-js/build/src/client-interceptors.js";
 import { ConnectionOptions } from "tls";
+import * as net from "net";
+import { SecureConnector } from "@grpc/grpc-js/build/src/channel-credentials.js";
 
 // NOTE: Copied from channel-credentials.ts in gRPC Node package because its not exported:
 // https://github.com/grpc/grpc-node/blob/3106057f5ad8f79a71d2ae411e116ad308a2e835/packages/grpc-js/src/call-credentials.ts#L143
 class ComposedChannelCredentials extends grpc.ChannelCredentials {
   constructor(
     private channelCredentials: KnownInsecureChannelCredentialsImpl,
-    callCreds: grpc.CallCredentials
+    private callCreds: grpc.CallCredentials
   ) {
-    super(callCreds);
+    super();
   }
   compose(callCredentials: grpc.CallCredentials) {
     const combinedCallCredentials =
-      this.callCredentials.compose(callCredentials);
+      this.callCreds.compose(callCredentials);
     return new ComposedChannelCredentials(
       this.channelCredentials,
       combinedCallCredentials
@@ -26,6 +28,22 @@ class ComposedChannelCredentials extends grpc.ChannelCredentials {
   _isSecure(): boolean {
     return false;
   }
+
+  _createSecureConnector(
+    _channelTarget, 
+    _options, 
+    callCredentials?: grpc.CallCredentials
+  ): SecureConnector {
+    return {
+      connect: async (socket: net.Socket) => {
+        return { socket, secure: false };
+      },
+      waitForReady: async () => {},
+      getCallCredentials: () => callCredentials || this.callCreds,
+      destroy: () => {}
+    };
+  }
+
   _equals(other: grpc.ChannelCredentials): boolean {
     if (this === other) {
       return true;
@@ -33,7 +51,7 @@ class ComposedChannelCredentials extends grpc.ChannelCredentials {
     if (other instanceof ComposedChannelCredentials) {
       return (
         this.channelCredentials._equals(other.channelCredentials) &&
-        this.callCredentials._equals(other.callCredentials)
+        this.callCreds._equals(other.callCreds)
       );
     } else {
       return false;
@@ -44,14 +62,9 @@ class ComposedChannelCredentials extends grpc.ChannelCredentials {
 // Create our own known insecure channel creds.
 // See https://github.com/grpc/grpc-node/issues/543 for why this is necessary.
 class KnownInsecureChannelCredentialsImpl extends grpc.ChannelCredentials {
-  constructor(callCredentials?: grpc.CallCredentials) {
-    super(callCredentials);
-  }
 
   compose(callCredentials: grpc.CallCredentials): grpc.ChannelCredentials {
-    const combinedCallCredentials =
-      this.callCredentials.compose(callCredentials);
-    return new ComposedChannelCredentials(this, combinedCallCredentials);
+    return new ComposedChannelCredentials(this, callCredentials);
   }
 
   _getConnectionOptions(): ConnectionOptions {


### PR DESCRIPTION
Related #206 

Implemented basic `_createSecureConnector` and made `callCreds` private to fix broken stuff ([this PR](https://github.com/grpc/grpc-node/pull/2866/files#diff-7c43d37a239cc91464d8ba94c2ece274bdf5146da1442603b7dc9fdd9b4f8483)), tested locally, also updates example