### PR TITLE
Pin grpc-js to version that works with the code we're using 

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "build-js-client": "tsc --declaration false --outDir js-dist"
   },
   "dependencies": {
-    "@grpc/grpc-js": "~1.12.5",
+    "@grpc/grpc-js": "~1.13.0",
     "@protobuf-ts/runtime": "^2.9.6",
     "@protobuf-ts/runtime-rpc": "^2.9.6",
     "google-protobuf": "^3.21.4"


### PR DESCRIPTION
## Description
In #212, we changed the code that we're using to implement the insecure channel credentials; we didn't also bump this version. If a user currently has a matching 1.12.x version, they won't get the upgrade, and their install of `authzed-node` won't work. This fixes that problem.

Note that we wouldn't have caught that in tests because this would only materialize for someone using a lockfile, and this package doesn't have a lockfile.

## Changes
* Pin to 1.13.x

## Testing
Review; see that tests go green.