### PR TITLE
Add test with caveat context in relation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "only-run-tests": "vitest",
     "buf": "buf generate && tsc-esm-fix --src src/authzedapi --ext='.js'",
     "lint": "./node_modules/.bin/eslint src",
+    "format": "prettier -w src",
     "build": "tsc",
     "postbuild": "rollup dist/src/index.js --file dist/src/index.cjs --format cjs && cp dist/src/index.d.ts dist/src/index.d.cts",
     "prepublish": "yarn build",


### PR DESCRIPTION
## Description
A user asked in #224 how to put caveat context in relationships; this test should demonstrate how it's done, and the test passing indicates that it's working.

## Changes
* Add a separate test for caveats where the context is set on the relation rather than on the request
* Remove some overspecified options
* Add an alias for formatting
## Testing
Review. See that tests pass.