### PR TITLE
update authzed-node to support materialize apis

### DIFF
--- a/src/v1.ts
+++ b/src/v1.ts
@@ -28,15 +28,19 @@ export type ZedDefaultClientInterface = OmitBaseMethods<
   OmitBaseMethods<SchemaServiceClient, grpc.Client> &
   OmitBaseMethods<WatchServiceClient, grpc.Client> &
   OmitBaseMethods<ExperimentalServiceClient, grpc.Client> &
+  OmitBaseMethods<WatchPermissionsServiceClient, grpc.Client> &
+  OmitBaseMethods<WatchPermissionSetsServiceClient, grpc.Client> &
   Pick<grpc.Client, "close">;
 
 // The promisified version of the interface
 export type ZedPromiseClientInterface =
   PromisifiedClient<PermissionsServiceClient> &
     PromisifiedClient<SchemaServiceClient> &
-    PromisifiedClient<WatchServiceClient> &
-    PromisifiedClient<ExperimentalServiceClient> &
-    Pick<ZedDefaultClientInterface, "close">;
+  PromisifiedClient<WatchServiceClient> &
+  PromisifiedClient<ExperimentalServiceClient> &
+  PromisifiedClient<WatchPermissionsServiceClient> &
+  PromisifiedClient<WatchPermissionSetsServiceClient> &
+  Pick<ZedDefaultClientInterface, "close">;
 
 // A combined client containing the root gRPC client methods and a promisified set at a "promises" key
 export type ZedClientInterface = ZedDefaultClientInterface & {
@@ -124,7 +128,7 @@ class ZedClient implements ProxyHandler<ZedDefaultClientInterface> {
   }
 
   close = () => {
-    [this.acl, this.ns, this.watch, this.experimental].forEach((client) =>
+    [this.acl, this.ns, this.watch, this.experimental, this.watchPermissions, this.watchPermissionSets].forEach((client) =>
       client?.close(),
     );
   };


### PR DESCRIPTION
This update extends the ZedClient interface to include WatchPermissionsServiceClient and WatchPermissionSetsServiceClient from the materialize v0 APIs.