### PR TITLE
Fix export of deadlineInterceptor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@
 
 export * as protobuf from "./protobuf.js";
 export * as v1 from "./v1.js";
+export { deadlineInterceptor } from "./util.js";


### PR DESCRIPTION
## Description
This used to be exposed implicitly, but when we made exports explicit to fix CJS bundling we hid this export. This fixes that.

## Changes
* Export deadlineInterceptor
## Testing
Review. See that build passes.