### PR TITLE
Expose ErrorReason enum in exports

### DIFF
--- a/src/v1.ts
+++ b/src/v1.ts
@@ -27,6 +27,8 @@ import type { JsonObject } from "@protobuf-ts/runtime";
 
 export { ImportedPbStruct as PbStruct, ImportedPbNullValue as PbNullValue };
 
+export { ErrorReason } from "./authzedapi/authzed/api/v1/error_reason.js";
+
 // A merge of the three generated gRPC clients, with their base methods omitted
 export type ZedDefaultClientInterface = OmitBaseMethods<
   PermissionsServiceClient,


### PR DESCRIPTION
## Description
This was raised by a discord user: https://discord.com/channels/844600078504951838/844600078948630559/1424792180207128588

Everything in this library that needs to be exposed needs to be explicitly exported. The `ErrorReason` enum wasn't one of those things. This fixes that.

## Changes
* Export the `ErrorReason` enum
## Testing
Review. See that tests pass. See that you can then import the `ErrorReason` enum and compare against it.