### PR TITLE
chore: add conventional commit linting

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     groups:
       npm:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,3 +21,7 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"

--- a/.github/workflows/automatic-api-update.yaml
+++ b/.github/workflows/automatic-api-update.yaml
@@ -40,8 +40,9 @@ jobs:
         with:
           delete-branch: "true"
           title: "Update API to ${{ github.event.client_payload.BUFTAG }}"
+          commit-message: "chore: update api version"
           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
           draft: "always-true"
           branch: "api-change/${{ github.event.client_payload.BUFTAG }}"
           base: "main"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,32 @@
+---
+name: "Lint"
+permissions:
+  contents: "read"
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  lint:
+    name: "Lint"
+    runs-on: "depot-ubuntu-24.04-small"
+    steps:
+      - uses: "actions/checkout@v5"
+      - uses: "bahmutov/npm-install@v1"
+        with:
+          useLockFile: false
+      - name: "Run prettier"
+        run: "CI=true yarn run prettier src -c"
+      - name: "Run lint"
+        run: "CI=true yarn lint"
+
+  conventional-commits:
+    name: "Lint Commit Messages"
+    runs-on: "depot-ubuntu-24.04-small"
+    if: "github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.action == 'edited')"
+    steps:
+      - uses: "actions/checkout@v5"
+      - uses: "webiny/action-conventional-commits@v1.3.0"

--- a/.github/workflows/manual-api-update.yaml
+++ b/.github/workflows/manual-api-update.yaml
@@ -40,9 +40,10 @@ jobs:
         if: steps.buf-update.outputs.updated == 'true'
         with:
           delete-branch: "true"
-          title: Update API to ${{ inputs.buftag }}
+          title: "Update API to ${{ inputs.buftag }}"
+          commit-message: "chore: update api version"
           # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
           draft: "always-true"
-          branch: api-change/${{ inputs.buftag }}
+          branch: "api-change/${{ inputs.buftag }}"
           base: "main"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Lint and Test"
+name: "Test"
 on:
   push:
     branches:
@@ -25,7 +25,7 @@ jobs:
               - js-dist/package.json
               - buf.gen.yaml
   test:
-    name: Lint and Test
+    name: "Test"
     runs-on: "depot-ubuntu-24.04-small"
     strategy:
       matrix:
@@ -34,26 +34,22 @@ jobs:
     if: |
       needs.paths-filter.outputs.codechange == 'true'
     steps:
-      - uses: actions/checkout@v5
+      - uses: "actions/checkout@v5"
       - uses: "authzed/action-spicedb@v1"
         with:
           version: "latest"
-      - uses: actions/setup-node@v6
+      - uses: "actions/setup-node@v6"
         with:
           node-version: ${{ matrix.node-version }}
           cache-dependency-path: ./package.json
           cache: "yarn"
-      - uses: bahmutov/npm-install@v1
+      - uses: "bahmutov/npm-install@v1"
         with:
           useLockFile: false
-      - name: Run lint
-        run: "CI=true yarn lint"
-      - name: Run prettier
-        run: "CI=true yarn run prettier src -c"
       - name: Run Yarn tests
         run: "CI=true yarn only-run-tests"
   build-js-client:
-    name: Build and Test JS client
+    name: "Build and Test JS client"
     runs-on: "depot-ubuntu-24.04-small"
     strategy:
       matrix:


### PR DESCRIPTION
## Description
Part of preparing this repo for the use of `release-please`. We need to have conventional commits in place, so this adds a linter for that and does some other drive-by refactors to workflows.

## Changes
* Add conventional commit linting
* Make the `create-pull-request` action tag with a conventional commit (`feat` to trigger a release)
* Ensure that dependabot uses conventional commits
* Some drive-by refactors

## Testing
Review. See that tests pass.