### PR TITLE
fix: exclude test files from the published build

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint:package": "pnpm publint --pack npm",
     "format": "pnpm oxfmt",
     "format:check": "pnpm oxfmt --check",
-    "build": "pnpm tsc",
+    "build": "pnpm tsc -p tsconfig.build.json",
     "postbuild": "rollup dist/src/index.js --file dist/src/index.cjs --format cjs && cp dist/src/index.d.ts dist/src/index.d.cts",
     "prepublishOnly": "pnpm build",
     "build-js-client": "pnpm tsc --declaration false --outDir js-dist"

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "src/**/*.test.*"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
+  // Build config for the published package: excludes test files from dist/.
+  // `extends` REPLACES the base exclude array (it does not merge), so
+  // "node_modules" must be re-listed here alongside the test glob.
   "extends": "./tsconfig.json",
   "exclude": ["node_modules", "src/**/*.test.*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "src/**/*.test.*"]
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
     "typeRoots": ["node_modules/@types"]
   },
   "include": ["src"],
-  "exclude": ["node_modules", "src/**/*.test.*/*"]
+  "exclude": ["node_modules", "src/**/*.test.*"]
 }


### PR DESCRIPTION
Fixes #161.

*.test.ts files were compiled into dist/ and published to npm. The
tsconfig exclude pattern was `src/**/*.test.*/*`, whose trailing `/*`
only matches files inside a directory named like `*.test.*` (never
exists), so it excluded nothing.

Fixing the glob alone would break the `build-js-client` CI job, which
compiles into js-dist/ and runs the tests there. So this splits the
config:

- tsconfig.json: excludes only node_modules - tests stay included for
  editor type-checking and the build-js-client CI job.
- tsconfig.build.json (new): extends tsconfig.json and excludes
  src/**/*.test.*; the `build` script uses it for the published dist/.

Verified: `pnpm build` emits 0 test artifacts into dist/ (was 12) and
`npm pack --dry-run` ships zero test files; `pnpm build-js-client` still
emits its test files into js-dist/ so that CI job is unaffected.