### PR TITLE
fix: disable gRPC retries by default

### DIFF
--- a/src/v1.test.ts
+++ b/src/v1.test.ts
@@ -859,3 +859,38 @@ describe("createStructFromObject unit tests", () => {
     );
   });
 });
+
+describe("gRPC retry default (#200)", () => {
+  // Capture the channel options the client actually applies, via grpc-js's
+  // channelFactoryOverride hook (called with the final merged options).
+  function capturedChannelOptions(extra?: grpc.ClientOptions): grpc.ChannelOptions {
+    let captured: grpc.ChannelOptions = {};
+    const client = NewClient(
+      "tok",
+      "localhost:50051",
+      ClientSecurity.INSECURE_LOCALHOST_ALLOWED,
+      PreconnectServices.PERMISSIONS_SERVICE,
+      {
+        ...extra,
+        channelFactoryOverride: (
+          address: string,
+          creds: grpc.ChannelCredentials,
+          options: grpc.ChannelOptions,
+        ) => {
+          captured = options;
+          return new grpc.Channel(address, creds, options);
+        },
+      } as grpc.ClientOptions,
+    );
+    client.close();
+    return captured;
+  }
+
+  it("disables retries by default", () => {
+    expect(capturedChannelOptions()["grpc.enable_retries"]).toBe(0);
+  });
+
+  it("lets the caller re-enable retries", () => {
+    expect(capturedChannelOptions({ "grpc.enable_retries": 1 })["grpc.enable_retries"]).toBe(1);
+  });
+});

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -75,6 +75,7 @@ class ZedClient implements ProxyHandler<ZedDefaultClientInterface> {
   ) {
     this.options = {
       ...options,
+      "grpc.enable_retries": 0,
       interceptors: [
         ...(options?.interceptors ?? []),
 

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -98,7 +98,11 @@ class ZedClient implements ProxyHandler<ZedDefaultClientInterface> {
       this.watch = new WatchServiceClient(this.endpoint, this.creds, this.options);
     }
     if (preconnect & PreconnectServices.WATCH_PERMISSIONS_SERVICE) {
-      this.watchPermissions = new WatchPermissionsServiceClient(this.endpoint, this.creds, this.options);
+      this.watchPermissions = new WatchPermissionsServiceClient(
+        this.endpoint,
+        this.creds,
+        this.options,
+      );
     }
     if (preconnect & PreconnectServices.WATCH_PERMISSIONSETS_SERVICE) {
       this.watchPermissionSets = new WatchPermissionSetsServiceClient(

--- a/src/v1.ts
+++ b/src/v1.ts
@@ -74,8 +74,11 @@ class ZedClient implements ProxyHandler<ZedDefaultClientInterface> {
     options: grpc.ClientOptions | undefined,
   ) {
     this.options = {
-      ...options,
+      // Default to disabling gRPC retries to avoid unrecoverable failures
+      // through envoy/istio (see #112). Placed before ...options so callers can
+      // re-enable retries by passing "grpc.enable_retries" explicitly.
       "grpc.enable_retries": 0,
+      ...options,
       interceptors: [
         ...(options?.interceptors ?? []),
 
@@ -86,26 +89,26 @@ class ZedClient implements ProxyHandler<ZedDefaultClientInterface> {
     };
 
     if (preconnect & PreconnectServices.PERMISSIONS_SERVICE) {
-      this.acl = new PermissionsServiceClient(this.endpoint, this.creds, options);
+      this.acl = new PermissionsServiceClient(this.endpoint, this.creds, this.options);
     }
     if (preconnect & PreconnectServices.SCHEMA_SERVICE) {
-      this.ns = new SchemaServiceClient(this.endpoint, this.creds, options);
+      this.ns = new SchemaServiceClient(this.endpoint, this.creds, this.options);
     }
     if (preconnect & PreconnectServices.WATCH_SERVICE) {
-      this.watch = new WatchServiceClient(this.endpoint, this.creds, options);
+      this.watch = new WatchServiceClient(this.endpoint, this.creds, this.options);
     }
     if (preconnect & PreconnectServices.WATCH_PERMISSIONS_SERVICE) {
-      this.watchPermissions = new WatchPermissionsServiceClient(this.endpoint, this.creds, options);
+      this.watchPermissions = new WatchPermissionsServiceClient(this.endpoint, this.creds, this.options);
     }
     if (preconnect & PreconnectServices.WATCH_PERMISSIONSETS_SERVICE) {
       this.watchPermissionSets = new WatchPermissionSetsServiceClient(
         this.endpoint,
         this.creds,
-        options,
+        this.options,
       );
     }
     if (preconnect & PreconnectServices.EXPERIMENTAL_SERVICE) {
-      this.experimental = new ExperimentalServiceClient(this.endpoint, this.creds, options);
+      this.experimental = new ExperimentalServiceClient(this.endpoint, this.creds, this.options);
     }
   }
 


### PR DESCRIPTION
Fixes #200.

Disables gRPC client retries by default - the grpc retries fail unrecoverably (`RST_STREAM code 0`) through envoy/istio (#112). Overridable via `{ "grpc.enable_retries": 1 }`.

Also passes the merged options to preconnected clients (not the raw arg), so the default reaches them; as a side effect they now get the default 30s deadline that lazy clients already had.

Mitigation, not a proven fix for #112 (not reproducible locally). Adds a unit test asserting the default + override.