### PR TITLE
feat: add v1 subpath export

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ import { v1 } from "@authzed/authzed-node";
 const client = v1.NewClient("t_your_token_here_1234567deadbeef");
 ```
 
+Each API version is also available as a subpath export, so its members can be imported directly:
+
+```js
+import { NewClient, ClientSecurity } from "@authzed/authzed-node/v1";
+
+const client = NewClient("t_your_token_here_1234567deadbeef");
+```
+
 Or to use a custom certificate authority, load the CA certificate and pass the file reference to `NewClientWithCustomCert`.
 
 ```js

--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
   "main": "dist/src/index.cjs",
   "module": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "v1": [
+        "./dist/src/v1.d.ts"
+      ]
+    }
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {
@@ -35,6 +42,15 @@
       },
       "require": "./dist/src/index.cjs",
       "import": "./dist/src/index.js"
+    },
+    "./v1": {
+      "types": {
+        "import": "./dist/src/v1.d.ts",
+        "require": "./dist/src/v1.d.cts",
+        "default": "./dist/src/v1.d.ts"
+      },
+      "require": "./dist/src/v1.cjs",
+      "import": "./dist/src/v1.js"
     }
   },
   "scripts": {
@@ -46,7 +62,7 @@
     "format": "pnpm oxfmt",
     "format:check": "pnpm oxfmt --check",
     "build": "pnpm tsc",
-    "postbuild": "rollup dist/src/index.js --file dist/src/index.cjs --format cjs && cp dist/src/index.d.ts dist/src/index.d.cts",
+    "postbuild": "rollup dist/src/index.js --file dist/src/index.cjs --format cjs && cp dist/src/index.d.ts dist/src/index.d.cts && rollup dist/src/v1.js --file dist/src/v1.cjs --format cjs && cp dist/src/v1.d.ts dist/src/v1.d.cts",
     "prepublishOnly": "pnpm build",
     "build-js-client": "pnpm tsc --declaration false --outDir js-dist"
   },


### PR DESCRIPTION
Fixes #52

Adds a `./v1` subpath export so the v1 client can be imported directly as `import { NewClient } from "@authzed/authzed-node/v1"`, alongside the existing root `import { v1 }`. `typesVersions` covers node10-style resolution; `postbuild` now also emits the CJS bundle and its declarations.